### PR TITLE
Add link to Autodistill module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - #### State-of-the-art performance on open-vocabulary LVIS
 - #### Deployed with modern visual foudation models
 
+[Use CoDet to automatically label images for training a small, fine-tuned model](https://github.com/autodistill/autodistill-codet)
 
 ## Installation
 Setup environment


### PR DESCRIPTION
Hello there! I'm an engineer at Roboflow. I was playing around with CoDet yesterday. I'm a big fan. We have worked with DETIC before and it has proved invaluable to some of our projects. Seeing improvements in mAP on the LVIS dataset is exciting.

I packaged CoDet into an `autodistill` module yesterday. [Autodistill](https://github.com/autodistill/autodistill) is a framework that lets you use foundation models like Grounding DINO, CLIP, and Segment Anything to automatically label images for use in training smaller, fine-tuned models. 

Autodistill is integrated with [supervision](https://github.com/roboflow/supervision), a Python package used by hundreds of open source projects for a range of computer vision use cases. This integration allows one to easily filter detections, plot predictions, and more.

This PR includes a link to the CoDet Autodistill module.